### PR TITLE
Fix Event Clobbering

### DIFF
--- a/app/assets/javascripts/md_simple_editor.js.coffee
+++ b/app/assets/javascripts/md_simple_editor.js.coffee
@@ -95,8 +95,10 @@ insertAtCaret = (areaId, text) ->
     txtarea.focus()
   txtarea.scrollTop = scrollPos
 
-$(document).on 'turbolinks:load page:load ready', ->
-  md_simple_editor()
-  $(document).off 'turbolinks:load page:load ready'
+initializeEditor = ->
+  md_simple_editor
+  $(document).off 'turbolinks:load page:load ready', initializeEditor
   $('.preview_md').click ->
     preview()
+
+$(document).on 'turbolinks:load page:load ready', initializeEditor

--- a/app/assets/javascripts/md_simple_editor.js.coffee
+++ b/app/assets/javascripts/md_simple_editor.js.coffee
@@ -96,7 +96,7 @@ insertAtCaret = (areaId, text) ->
   txtarea.scrollTop = scrollPos
 
 initializeEditor = ->
-  md_simple_editor
+  md_simple_editor()
   $(document).off 'turbolinks:load page:load ready', initializeEditor
   $('.preview_md').click ->
     preview()


### PR DESCRIPTION
Using 
```coffeescript
$(document).off 'turbolinks:load page:load ready'
```
clobbers all load events on the document, including ones added by other features.

By refactoring and passing a function pointer instead, only the method we want cleared will be removed.