### PR TITLE
allow use of boostrap 4 with boostrap gem and md_simple_editor 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Add this line to your application's Gemfile:
 
     gem 'md_simple_editor'
 
+If you don't have boostrap in your project add this line to your application's Gemfile:
+
+    gem 'bootstrap-sass', '~> 3.3.7'
+
 And then execute:
 
     $ bundle install

--- a/lib/md_simple_editor.rb
+++ b/lib/md_simple_editor.rb
@@ -1,7 +1,6 @@
 require 'md_simple_editor/version'
 require 'redcarpet'
 require 'font-awesome-rails'
-require 'bootstrap-sass'
 require 'md_simple_editor/engine' if defined?(Rails)
 require 'md_simple_editor/md_builder'
 

--- a/md_simple_editor.gemspec
+++ b/md_simple_editor.gemspec
@@ -23,5 +23,4 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'font-awesome-rails'
   spec.add_runtime_dependency 'redcarpet', '~> 3.4'
-  spec.add_runtime_dependency 'bootstrap-sass', '~> 3.3.7'
 end


### PR DESCRIPTION
allow use of boostrap 4 with boostrap gem and md_simple_editor  together by removing bootstrap-sass dependency from gemspec

Problem : Boostrap 2 and 3 use the boostrap-sass gem, boostrap 4 use the boostrap gem.
Using md_simple_editor with boostrap gem cause both boostrap 3 and 4 being installed causing warnings 
`.../gems/bootstrap-sass-3.3.7/lib/bootstrap-sass/version.rb:2: warning: already initialized constant Bootstrap::VERSION
.../gems/bootstrap-4.1.1/lib/bootstrap/version.rb:2: warning: previous definition of VERSION was here
.../gems/bootstrap-sass-3.3.7/lib/bootstrap-sass/version.rb:3: warning: already initialized constant Bootstrap::BOOTSTRAP_SHA
.../gems/ruby-2.5.1@premium_today/gems/bootstrap-4.1.1/lib/bootstrap/version.rb:3: warning: previous definition of BOOTSTRAP_SHA was here
`
Solution : Removing boostrap-sass as a gem dependency and let users install themself boostrap-sass or boostrap gem