### PR TITLE
Add margin to text and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 Add this line to your application's Gemfile:
 
+    gem 'font-awesome-rails'
     gem 'md_simple_editor'
 
 And then execute:
@@ -14,13 +15,20 @@ And then execute:
 
 Or install it yourself as:
 
+    $ gem install font-awesome-rails
     $ gem install md_simple_editor
 
 ## Usage
 
 In your `application.css`, include the css files:
     
+    *= require font-awesome
     *= require md_simple_editor
+    
+Or if you using SCSS, include in `application.css.scss`:
+    
+    @import "font-awesome";
+    @import "md_simple_editor";
 
 In your `application.js`, include the javascript files:
 

--- a/app/assets/stylesheets/md_simple_editor.css.scss
+++ b/app/assets/stylesheets/md_simple_editor.css.scss
@@ -4,6 +4,7 @@
 
 #md-editor{
   #md-text{
+    margin-bottom: 10px;
     textarea{
       padding: 15px;
     }

--- a/app/assets/stylesheets/md_simple_editor.css.scss
+++ b/app/assets/stylesheets/md_simple_editor.css.scss
@@ -4,7 +4,8 @@
 
 #md-editor{
   #md-text{
-    margin-bottom: 10px;
+    margin-top: 10px;
+    
     textarea{
       padding: 15px;
     }

--- a/app/helpers/md_simple_editor/rails/md_helper.rb
+++ b/app/helpers/md_simple_editor/rails/md_helper.rb
@@ -14,7 +14,6 @@ module MdSimpleEditor
                   end
                 end
           end +
-              content_tag(:br) +
               content_tag(:div, :id => 'md-text') do
                 yield
               end +

--- a/md_simple_editor.gemspec
+++ b/md_simple_editor.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'font-awesome-rails'
   spec.add_runtime_dependency 'redcarpet', '~> 3.4'
-  spec.add_runtime_dependency 'bootstrap-sass', '~> 3.3.7'
+  spec.add_runtime_dependency 'bootstrap-sass', '>= 3.3.7'
 end


### PR DESCRIPTION
Add margin-top to text. It's more flexible than <br> tag.
Update bootstrap gem version ( now it's '>=' instead '~>' )
Update README.md, add font-awesome, like on http://rderoldan1.github.io/md_simple_editor/ , and add SCSS instructions.